### PR TITLE
Fixed launcher startup and collected file exploring

### DIFF
--- a/Command/TempDirectoryPreparation.cs
+++ b/Command/TempDirectoryPreparation.cs
@@ -7,7 +7,9 @@ namespace SupportTool.Command
     {
         public void Execute(Config config, FileAggregator fileAggregator, LoggerInterface logger, Propagation propagation)
         {
-            if (!Directory.Exists(fileAggregator.TempDir))
+            DirectoryInfo tempDir = new DirectoryInfo(fileAggregator.TempDir);
+
+            if (!tempDir.Exists)
             {
                 logger.Log(string.Format("Created {0}", fileAggregator.TempDir));
                 Directory.CreateDirectory(fileAggregator.TempDir);
@@ -16,8 +18,15 @@ namespace SupportTool.Command
 
             logger.Log(string.Format("Cleaning up old files in {0}", fileAggregator.TempDir));
 
-            Directory.Delete(fileAggregator.TempDir, true);
-            Directory.CreateDirectory(fileAggregator.TempDir);
+            foreach (FileInfo file in tempDir.GetFiles())
+            {
+                file.Delete();
+            }
+
+            foreach (DirectoryInfo dir in tempDir.GetDirectories())
+            {
+                dir.Delete(true);
+            }
 
             fileAggregator.AggregatedFiles.Clear();
         }

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -183,7 +183,12 @@ namespace SupportTool
                 return;
             }
 
-            Process.Start(config.DnInstallationDirectory);
+            var process = Process.Start(new ProcessStartInfo()
+            {
+                FileName = config.DnInstallationDirectory,
+                UseShellExecute = true,
+                Verb = "Open"
+            });
         }
 
         private void ChangeChangeInstallationDirectory_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Closed #4.

This PR fixes 2 bugs:
 - Opening the launcher based on whether or not administrator permissions were granted to the support tool or the tool was not installed in Program Files, gave different behavior on the debug launcher (#4).
 - When having the collected files open via the tool, it could crash upon collecting data again.

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1095736/support-tool.zip)

