### PR TITLE
Fixed line endings in readme template

### DIFF
--- a/Assets/CustomerSupportReadme.txt
+++ b/Assets/CustomerSupportReadme.txt
@@ -1,4 +1,4 @@
-﻿Files gathered and archived by the Dreadnought Community Support Tool ({version}).
+Files gathered and archived by the Dreadnought Community Support Tool ({version}).
 
 The Dreadnought Community Support Tool can be found at:
  - https://github.com/dreadnought-friends/support-tool


### PR DESCRIPTION
Because the newlines in the template were unix based, everything was put on 1 line. It's windows CRLF now. 

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1099555/support-tool.zip)
