### PR TITLE
Changed the output of msinfo32 to nfo

### DIFF
--- a/Command/MsInfo.cs
+++ b/Command/MsInfo.cs
@@ -15,14 +15,14 @@ namespace SupportTool.Command
 
             logger.Log("Generating msinfo32 dump");
 
-            FileInfo reportFile = fileAggregator.AddVirtualFile("msinfo32.txt");
+            FileInfo reportFile = fileAggregator.AddVirtualFile("msinfo32.nfo");
 
             Process process = new Process();
             process.EnableRaisingEvents = true;
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.FileName = "msinfo32.exe";
             process.StartInfo.CreateNoWindow = true;
-            process.StartInfo.Arguments = string.Format("/report {0}", reportFile.FullName);
+            process.StartInfo.Arguments = string.Format("/nfo {0}", reportFile.FullName);
             process.Start();
             process.WaitForExit();
             process.Close();

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -49,5 +49,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -55,11 +55,11 @@ namespace SupportTool
                 WindowsPrincipal principal = new WindowsPrincipal(identity);
                 isElevated = principal.IsInRole(WindowsBuiltInRole.Administrator);
             }
-            
+
             config = new Config(
                 version,
-                Path.Combine(home, @"AppData\Local\DreadGame\Saved\Logs"),
-                Path.Combine(home, "Desktop"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"DreadGame\Saved\Logs"),
+                Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory),
                 "DN_Support.zip",
                 "https://raw.githubusercontent.com/dreadnought-friends/tool-versions/master/versions.xml",
                 isElevated


### PR DESCRIPTION
Customer Support prefers to have the msinfo32 export as NFO to enhance readability. 

 - Changed the output of msinfo32 to nfo
 - Using properly resolved paths for local app data and desktop directory
 - Bumped the version to 2.1.1

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1120123/support-tool.zip)
