### PR TITLE
Added support for crash dump aggregation

### DIFF
--- a/Command/DreadnoughtCrashDumps.cs
+++ b/Command/DreadnoughtCrashDumps.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SupportTool.Command
+{
+    class DreadnoughtCrashDumps : CommandInterface
+    {
+        public void Execute(Config config, FileAggregator fileAggregator, LoggerInterface logger, Propagation propagation)
+        {
+            if (!config.IncludeDreadnoughtCrashDumps)
+            {
+                logger.Log("Skipping Dreadnought crash dumps");
+                return;
+            }
+
+            logger.Log("Gathering Dreadnought crash dumps");
+
+            List<DirectoryInfo> directories = Directory.GetDirectories(config.LogFileLocation)
+                .Select(x => new DirectoryInfo(x))
+                .Where(delegate (DirectoryInfo dir)
+                {
+                    return dir.EnumerateFiles()
+                        .Where(f => f.Name.Equals("UE4Minidump.dmp"))
+                        .Count() > 0;
+                })
+                .ToList();
+
+            foreach (DirectoryInfo dir in directories)
+            {
+                foreach (FileInfo file in dir.GetFiles())
+                {
+                    fileAggregator.AddExistingFile(file.FullName, Path.Combine("crash-dumps", dir.Name, file.Name));
+                }
+            }
+        }
+    }
+}

--- a/Command/DreadnoughtCrashDumps.cs
+++ b/Command/DreadnoughtCrashDumps.cs
@@ -21,7 +21,7 @@ namespace SupportTool.Command
                 .Where(delegate (DirectoryInfo dir)
                 {
                     return dir.EnumerateFiles()
-                        .Where(f => f.Name.Equals("UE4Minidump.dmp"))
+                        .Where(f => f.Name.EndsWith(".dmp"))
                         .Count() > 0;
                 })
                 .ToList();

--- a/Config.cs
+++ b/Config.cs
@@ -36,7 +36,7 @@ namespace SupportTool
 
         public bool CanCreateArchive
         {
-            get { return IncludeDreadnoughtLogs || IncludeDxDiag || IncludeMsInfo || IncludeHostDeveloper; }
+            get { return IncludeDreadnoughtLogs || IncludeDreadnoughtCrashDumps || IncludeDxDiag || IncludeMsInfo || IncludeHostDeveloper; }
         }
 
         public Config(string version, string logFileLocation, string zipFileLocation, string zipFileName, string versionInfoFileUrl, bool isElevated)

--- a/Config.cs
+++ b/Config.cs
@@ -31,13 +31,14 @@ namespace SupportTool
         public bool IncludeMsInfo { get; set; } = true;
         public bool IncludeDxDiag { get; set; } = true;
         public bool IncludeDreadnoughtLogs { get; set; } = true;
-        public bool IncludeHostDeveloper { get; set; } = false;
+        public bool IncludeHostDeveloper { get; set; } = true;
+        public bool IncludeDreadnoughtCrashDumps { get; set; } = true;
 
         public bool CanCreateArchive
         {
             get { return IncludeDreadnoughtLogs || IncludeDxDiag || IncludeMsInfo || IncludeHostDeveloper; }
         }
-
+        
         public Config(string version, string logFileLocation, string zipFileLocation, string zipFileName, string versionInfoFileUrl, bool isElevated)
         {
             Version = version;

--- a/Config.cs
+++ b/Config.cs
@@ -38,7 +38,7 @@ namespace SupportTool
         {
             get { return IncludeDreadnoughtLogs || IncludeDxDiag || IncludeMsInfo || IncludeHostDeveloper; }
         }
-        
+
         public Config(string version, string logFileLocation, string zipFileLocation, string zipFileName, string versionInfoFileUrl, bool isElevated)
         {
             Version = version;

--- a/SupportToolWindow.xaml
+++ b/SupportToolWindow.xaml
@@ -63,6 +63,7 @@
                         </TextBlock>
                     </CheckBox.ToolTip>
                 </CheckBox>
+                <CheckBox x:Name="SettingCrashDumps" Margin="3,3,0,0" Content="Include Dreadnought crash dumps" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding IncludeDreadnoughtCrashDumps, Mode=TwoWay}" />
                 <CheckBox x:Name="SettingArchive" Margin="3,3,0,0" Content="Create ZIP archive" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding CreateZipArchive, Mode=TwoWay}" />
             </StackPanel>
             <Button x:Name="StartAggregation" Grid.Row="1" Content="Collect Selected Information" HorizontalAlignment="Left" Click="StartAggregation_Click" Padding="5,0,5,0" Height="20"/>

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -77,6 +77,7 @@ namespace SupportTool
             commands.Add(new DxDiag());
             commands.Add(new MsInfo());
             commands.Add(new DreadnoughtLogs());
+            commands.Add(new DreadnoughtCrashDumps());
             commands.Add(new AggregatedFileCollector());
             commands.Add(new Archiver());
 

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -92,6 +92,7 @@
     </Compile>
     <Compile Include="Command\CustomerSupportReadme.cs" />
     <Compile Include="Command\Archiver.cs" />
+    <Compile Include="Command\DreadnoughtCrashDumps.cs" />
     <Compile Include="Command\TempDirectoryPreparation.cs" />
     <Compile Include="Command\DreadnoughtLogs.cs" />
     <Compile Include="Command\DxDiag.cs" />


### PR DESCRIPTION
This PR adds the ability to aggregate crash dumps from the log directory. It tries to find all directories which contain a `UE4Minidump.dmp` and collects all files from that directory.

Additionally, I have turned on the host developer file by default to try and reduce the possible contact moments with CS.

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1239597/support-tool.zip)

