### PR TITLE
Bump to 2.2.0 with a final fix

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -49,5 +49,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -137,6 +137,7 @@ namespace SupportTool
             SettingDxDiag.IsEnabled = true;
             SettingMsInfo.IsEnabled = true;
             SettingLogFiles.IsEnabled = true;
+            SettingCrashDumps.IsEnabled = true;
             SettingArchive.IsEnabled = true;
             SettingHostDeveloper.IsEnabled = true;
             StartAggregation.IsEnabled = true;
@@ -154,6 +155,7 @@ namespace SupportTool
             SettingDxDiag.IsEnabled = false;
             SettingMsInfo.IsEnabled = false;
             SettingLogFiles.IsEnabled = false;
+            SettingCrashDumps.IsEnabled = false;
             SettingArchive.IsEnabled = false;
             SettingHostDeveloper.IsEnabled = false;
             StartAggregation.IsEnabled = false;


### PR DESCRIPTION
Bumps the app to 2.2.0 and fixes a bug where in the UI the checkbox wasn't properly disabled during aggregation.

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1239824/support-tool.zip)
