### PR TITLE
Added a ping and tracert for known servers

### DIFF
--- a/Command/Connection.cs
+++ b/Command/Connection.cs
@@ -1,0 +1,66 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Net.NetworkInformation;
+
+namespace SupportTool.Command
+{
+    class Connection : CommandInterface
+    {
+        private string[] IpPings = new string[] {
+            "172.86.100.9",
+            "172.86.100.100",
+            "172.86.100.101",
+            "172.86.100.102",
+            "172.86.100.103",
+            "172.86.100.104",
+            "172.86.100.105",
+            "172.86.100.106",
+            "172.86.100.107"
+        };
+
+        public void Execute(Config config, FileAggregator fileAggregator, LoggerInterface logger, Propagation propagation)
+        {
+            if (!config.IncludeConnection)
+            {
+                logger.Log("Skipping connection information to the Dreadnought servers");
+                return;
+            }
+
+            logger.Log("Generating connection information to the Dreadnought servers, this might take a while");
+
+            FileInfo reportFile = fileAggregator.AddVirtualFile("connection-information.txt");
+
+            using (StreamWriter writer = reportFile.CreateText())
+            {
+
+                logger.Log("Tracing route to one of the servers");
+                writer.WriteLine(string.Format("==== TRACERT: {0} ====", IpPings[0]));
+                writer.WriteLine(probeConnection("tracert", IpPings[0]));
+
+                logger.Log("Pinging known dreadnought servers");
+                foreach (string ipAddress in IpPings)
+                {
+                    writer.WriteLine(string.Format("==== PING: {0} ====", ipAddress));
+                    writer.WriteLine(probeConnection("ping", ipAddress));
+                }
+            }
+        }
+
+        private static string probeConnection(string command, string host)
+        {
+            Process process = new Process();
+            process.EnableRaisingEvents = true;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.FileName = command;
+            process.StartInfo.Arguments = host;
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.Start();
+            process.WaitForExit();
+            string output = process.StandardOutput.ReadToEnd();
+            process.Close();
+
+            return output;
+        }
+    }
+}

--- a/Config.cs
+++ b/Config.cs
@@ -30,13 +30,14 @@ namespace SupportTool
         public bool CreateZipArchive { get; set; } = true;
         public bool IncludeMsInfo { get; set; } = true;
         public bool IncludeDxDiag { get; set; } = true;
+        public bool IncludeConnection { get; set; } = true;
         public bool IncludeDreadnoughtLogs { get; set; } = true;
         public bool IncludeHostDeveloper { get; set; } = true;
         public bool IncludeDreadnoughtCrashDumps { get; set; } = true;
 
         public bool CanCreateArchive
         {
-            get { return IncludeDreadnoughtLogs || IncludeDreadnoughtCrashDumps || IncludeDxDiag || IncludeMsInfo || IncludeHostDeveloper; }
+            get { return IncludeDreadnoughtLogs || IncludeDreadnoughtCrashDumps || IncludeConnection || IncludeDxDiag || IncludeMsInfo || IncludeHostDeveloper; }
         }
 
         public Config(string version, string logFileLocation, string zipFileLocation, string zipFileName, string versionInfoFileUrl, bool isElevated)

--- a/SupportToolWindow.xaml
+++ b/SupportToolWindow.xaml
@@ -55,11 +55,18 @@
                 </Label>
                 <CheckBox x:Name="SettingDxDiag" Margin="3,3,0,0" Content="Include DxDiag" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding IncludeDxDiag, Mode=TwoWay}"/>
                 <CheckBox x:Name="SettingMsInfo" Margin="3,3,0,0" Content="Include MsInfo32" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding IncludeMsInfo, Mode=TwoWay}" />
+                <CheckBox x:Name="SettingConnection" Margin="3,3,0,0" Content="Include connection info" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding IncludeConnection, Mode=TwoWay}">
+                    <CheckBox.ToolTip>
+                        <TextBlock TextWrapping="Wrap" Width="300">
+                            A ping and traceroute will be executed for several IP addresses. Depending on how fast your connection to the server is at moment, it might take a while.
+                        </TextBlock>
+                    </CheckBox.ToolTip>
+                </CheckBox>
                 <CheckBox x:Name="SettingLogFiles" Margin="3,3,0,0" Content="Include Dreadnought log files" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding IncludeDreadnoughtLogs, Mode=TwoWay}" />
                 <CheckBox x:Name="SettingHostDeveloper" Margin="3,3,0,0" Content="Include host developer debug file" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding IncludeHostDeveloper, Mode=TwoWay}" ToolTipService.InitialShowDelay="0" ToolTipService.ShowDuration="30000">
                     <CheckBox.ToolTip>
                         <TextBlock TextWrapping="Wrap" Width="300">
-                        To generate this file, the launcher will be started in debug mode which may require you to give permissions to start under administrator privileges. It might take roughly 30 seconds or more for this to show.
+                            To generate this file, the launcher will be started in debug mode which may require you to give permissions to start under administrator privileges. It might take roughly 30 seconds or more for this to show.
                         </TextBlock>
                     </CheckBox.ToolTip>
                 </CheckBox>

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -76,6 +76,7 @@ namespace SupportTool
             commands.Add(new CustomerSupportReadme());
             commands.Add(new DxDiag());
             commands.Add(new MsInfo());
+            commands.Add(new Connection());
             commands.Add(new DreadnoughtLogs());
             commands.Add(new DreadnoughtCrashDumps());
             commands.Add(new AggregatedFileCollector());
@@ -136,6 +137,7 @@ namespace SupportTool
         {
             SettingDxDiag.IsEnabled = true;
             SettingMsInfo.IsEnabled = true;
+            SettingConnection.IsEnabled = true;
             SettingLogFiles.IsEnabled = true;
             SettingCrashDumps.IsEnabled = true;
             SettingArchive.IsEnabled = true;
@@ -154,6 +156,7 @@ namespace SupportTool
         {
             SettingDxDiag.IsEnabled = false;
             SettingMsInfo.IsEnabled = false;
+            SettingConnection.IsEnabled = false;
             SettingLogFiles.IsEnabled = false;
             SettingCrashDumps.IsEnabled = false;
             SettingArchive.IsEnabled = false;

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Command\CustomerSupportReadme.cs" />
     <Compile Include="Command\Archiver.cs" />
     <Compile Include="Command\DreadnoughtCrashDumps.cs" />
+    <Compile Include="Command\Connection.cs" />
     <Compile Include="Command\TempDirectoryPreparation.cs" />
     <Compile Include="Command\DreadnoughtLogs.cs" />
     <Compile Include="Command\DxDiag.cs" />


### PR DESCRIPTION
Closes #15. 

This PR adds the option to ping and trace the route to some known game servers. All IPs listed are found in the game logs and can be seen in the resource manager of windows when you check the Dreadnought executable connections.

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1252810/support-tool.zip)
Generated Archive: [DN_Support.zip](https://github.com/dreadnought-friends/support-tool/files/1252813/DN_Support.zip)

Please check if output is clear enough.

![image](https://user-images.githubusercontent.com/1754678/29729433-6742ddf6-89dc-11e7-9b2e-c961b23d0ddc.png)
