### PR TITLE
IP lookup in logs instead of a static list

### DIFF
--- a/Ping/IpFinder.cs
+++ b/Ping/IpFinder.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace SupportTool.Ping
+{
+    class IpFinder
+    {
+        public static HashSet<string> findIps(FileInfo logFile)
+        {
+            StreamReader file = new StreamReader(logFile.FullName);
+            Regex regex = new Regex(@"(172\.)((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){2}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)");
+            HashSet<string> ipAddresses = new HashSet<string>();
+
+            string line;
+            while ((line = file.ReadLine()) != null)
+            {
+                MatchCollection matches = regex.Matches(line);
+                if (0 == matches.Count)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < matches.Count; i++)
+                {
+                    ipAddresses.Add(matches[i].ToString());
+                }
+            }
+
+            return ipAddresses;
+        }
+    }
+}

--- a/Runner.cs
+++ b/Runner.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace SupportTool
 {
@@ -29,6 +30,11 @@ namespace SupportTool
 
                 command.Execute(config, fileAggregator, logger, propagation);
             }
+        }
+        
+        public void reportException(Exception e)
+        {
+            logger.Log(e.ToString());
         }
     }
 }

--- a/Runner.cs
+++ b/Runner.cs
@@ -20,6 +20,7 @@ namespace SupportTool
         {
             Propagation propagation = new Propagation();
 
+
             foreach (CommandInterface command in commands)
             {
                 if (propagation.ShouldStop)
@@ -28,13 +29,18 @@ namespace SupportTool
                     return;
                 }
 
-                command.Execute(config, fileAggregator, logger, propagation);
+                try
+                {
+                    command.Execute(config, fileAggregator, logger, propagation);
+                }
+                catch (Exception e)
+                {
+                    logger.Log(e.ToString());
+#if DEBUG
+                    throw e;
+#endif
+                }
             }
-        }
-        
-        public void reportException(Exception e)
-        {
-            logger.Log(e.ToString());
         }
     }
 }

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -114,17 +114,7 @@ namespace SupportTool
         {
             textBoxLogger.Clear();
 
-            try
-            {
-                runner.Run(commands);
-            }
-            catch (Exception exception)
-            {
-                runner.reportException(exception);
-#if DEBUG
-                throw exception;
-#endif
-            }
+            runner.Run(commands);
         }
 
         private void FinishAggregateData(object sender, RunWorkerCompletedEventArgs e)

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -120,17 +120,11 @@ namespace SupportTool
             }
             catch (Exception exception)
             {
-                LogCriticalError(exception.Message);
+                runner.reportException(exception);
+#if DEBUG
+                throw exception;
+#endif
             }
-        }
-
-        private void LogCriticalError(string message)
-        {
-            textBoxLogger.Log("[ERROR]-------------------------------------");
-            textBoxLogger.Log("An unexpected error has occured preventing the program from collecting data.");
-            textBoxLogger.Log(message);
-            textBoxLogger.Log("[ERROR]-------------------------------------");
-            textBoxLogger.Log("Please report this error at https://github.com/dreadnought-friends/support-tool");
         }
 
         private void FinishAggregateData(object sender, RunWorkerCompletedEventArgs e)

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -113,6 +113,7 @@
     <Compile Include="CommandInterface.cs" />
     <Compile Include="Command\MsInfo.cs" />
     <Compile Include="Logger\TextBoxLogger.cs" />
+    <Compile Include="Ping\IpFinder.cs" />
     <Compile Include="Propagation.cs" />
     <Compile Include="Runner.cs" />
     <Compile Include="Config.cs" />


### PR DESCRIPTION
This PR ensures that there are only IP addresses in the list to ping that are actually contacted by the game (as logged). I've limited the IP addresses to `172.*` and this results in the same list of static IP addresses that I was using.

The only fragile part of this, could be that the IPs will no longer be logged by the game in the future, then it'll have have to be reverted to allow a static list of IPs.

This PR also fixes the exception logging. In DEBUG mode (when developing), the exception will be rethrown, while in release mode, it will simply log it to the user interface. The previous logging broke somewhere during a refactor. I've moved the actual logging to the runner for exceptions.

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1272093/support-tool.zip)


