### PR TITLE
Using native pings for more control and async

### DIFF
--- a/Command/Connection.cs
+++ b/Command/Connection.cs
@@ -70,7 +70,7 @@ namespace SupportTool.Command
             };
             process.Start();
 
-            logger.Log("Pinging known dreadnought servers");
+            logger.Log("Pinging known dreadnought servers, this might take a few seconds");
             using (StreamWriter writer = reportFile.CreateText())
             {
                 List<string> errors = new List<string>();

--- a/Ping/PingRequestReply.cs
+++ b/Ping/PingRequestReply.cs
@@ -1,0 +1,16 @@
+﻿using System.Net.NetworkInformation;
+
+namespace SupportTool.Ping
+{
+    class PingRequestReply
+    {
+        public string OriginalHost { get; private set; }
+        public PingReply PingReply { get; private set; }
+
+        public PingRequestReply(string originalHost, PingReply pingReply)
+        {
+            OriginalHost = originalHost;
+            PingReply = pingReply;
+        }
+    }
+}

--- a/Ping/PingResult.cs
+++ b/Ping/PingResult.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace SupportTool.Ping
+{
+    class PingResult
+    {
+        public string Host { get; private set; }
+        public bool Successful { get; private set; }
+        public double AveragePing { get; private set; }
+        public int PayloadSize { get; private set; }
+        public int PingAttempts { get; private set; }
+        public List<string> Errors { get; private set; }
+
+        public PingResult(string host, double averagePing, int payloadSize, int pingAttempts, List<string> errors)
+        {
+            Host = host;
+            AveragePing = averagePing;
+            PayloadSize = payloadSize;
+            PingAttempts = pingAttempts;
+            Successful = 0 == errors.Count;
+            Errors = errors;
+        }
+    }
+}

--- a/Ping/Pinger.cs
+++ b/Ping/Pinger.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SupportTool.Ping
+{
+    class Pinger
+    {
+        public static List<PingResult> PingHosts(List<string> hosts, int bufferSizeInBytes = 32)
+        {
+            byte[] buffer = Encoding.ASCII.GetBytes(new string('a', bufferSizeInBytes));
+
+            Dictionary<string, List<PingReply>> sortedResults = new Dictionary<string, List<PingReply>>();
+
+            // sort per IP
+            foreach (PingReply reply in PingAsync(hosts, buffer))
+            {
+                List<PingReply> item;
+                string host = reply.Address.ToString();
+                
+                if (!sortedResults.TryGetValue(host, out item))
+                {
+                    item = new List<PingReply>();
+                    sortedResults[host] = item;
+                }
+
+                item.Add(reply);
+            }
+
+            List<PingResult> pingResults = new List<PingResult>();
+
+            // calculate result per IP based on average
+            foreach (KeyValuePair<string, List<PingReply>> item in sortedResults)
+            {
+                List<string> errors = new List<string>();
+                long totalTime = 0;
+
+
+                foreach (PingReply reply in item.Value)
+                {
+                    if (reply.Status != IPStatus.Success)
+                    {
+                        errors.Add(String.Format("Connecting to {0} failed. Error: {1}.", reply.Address, reply.Status.ToString()));
+                        continue;
+                    }
+
+                    totalTime += reply.RoundtripTime;
+                }
+                
+                int actualPings = item.Value.Count - errors.Count;
+                if (actualPings == 0)
+                {
+                    Console.WriteLine(errors.ToString());
+                }
+
+                double average = actualPings > 0 ? totalTime / actualPings : 0;
+                pingResults.Add(new PingResult(item.Key, average, bufferSizeInBytes, item.Value.Count, errors));
+            }
+
+
+            return pingResults;
+        }
+
+        private static List<PingReply> PingAsync(List<string> hosts, byte[] buffer)
+        {
+            List<string> repeatedHosts = new List<string>();
+
+            for (int i = 0; i < 4; i++)
+            {
+                repeatedHosts.AddRange(hosts);
+            }
+
+            List<Task<PingReply>> pingTasks = new List<Task<PingReply>>();
+            foreach (var address in repeatedHosts)
+            {
+                pingTasks.Add(PingAsync(address));
+            }
+            
+            Task.WaitAll(pingTasks.ToArray());
+
+            return pingTasks.Select(t => t.Result).ToList();
+        }
+
+        private static Task<PingReply> PingAsync(string address)
+        {
+            var tcs = new TaskCompletionSource<PingReply>();
+            var ping = new System.Net.NetworkInformation.Ping();
+            ping.PingCompleted += (object sender, PingCompletedEventArgs e) =>
+            {
+                tcs.SetResult(e.Reply);
+            };
+            ping.SendAsync(address, new object());
+            return tcs.Task;
+        }
+    }
+}

--- a/Runner.cs
+++ b/Runner.cs
@@ -20,7 +20,6 @@ namespace SupportTool
         {
             Propagation propagation = new Propagation();
 
-
             foreach (CommandInterface command in commands)
             {
                 if (propagation.ShouldStop)

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Logger\TextBoxLogger.cs" />
     <Compile Include="Ping\IpFinder.cs" />
     <Compile Include="Ping\Pinger.cs" />
+    <Compile Include="Ping\PingRequestReply.cs" />
     <Compile Include="Ping\PingResult.cs" />
     <Compile Include="Propagation.cs" />
     <Compile Include="Runner.cs" />

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -114,6 +114,8 @@
     <Compile Include="Command\MsInfo.cs" />
     <Compile Include="Logger\TextBoxLogger.cs" />
     <Compile Include="Ping\IpFinder.cs" />
+    <Compile Include="Ping\Pinger.cs" />
+    <Compile Include="Ping\PingResult.cs" />
     <Compile Include="Propagation.cs" />
     <Compile Include="Runner.cs" />
     <Compile Include="Config.cs" />


### PR DESCRIPTION
This PR changes the pings from `ping.exe` to native C# functionality. It's a lot faster and I can properly ping async. It pings all known game servers (from the logs) with 32 and 256 bytes. Additionally, the `tracert.exe` is now async as well and as it's the slowest process, will be started before the pings.

This PR should speed up the connection information significantly, especially for connections with higher pings and makes it possible to ping an IP for the UI.

Example output: [connection-information.txt](https://github.com/dreadnought-friends/support-tool/files/1272275/connection-information.txt)
Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1272276/support-tool.zip)
