### PR TITLE
Less verbose in release mode, less clutter for end user

### DIFF
--- a/Command/AggregatedFileCollector.cs
+++ b/Command/AggregatedFileCollector.cs
@@ -23,7 +23,7 @@ namespace SupportTool.Command
                     return;
                 }
 
-                logger.Log(file.To.FullName);
+                logger.Debug(file.To.FullName);
             }
         }
     }

--- a/Command/Archiver.cs
+++ b/Command/Archiver.cs
@@ -43,7 +43,7 @@ namespace SupportTool.Command
 
             if (file.Exists)
             {
-                logger.Log(string.Format("Deleting old zip file {0}", zipFile));
+                logger.Debug(string.Format("Deleting old zip file {0}", zipFile));
                 file.Delete();
             }
 
@@ -57,7 +57,7 @@ namespace SupportTool.Command
                 return;
             }
 
-            logger.Log(string.Format("Creating {0}", zipFile));
+            logger.Debug(string.Format("Creating {0}", zipFile));
             ZipFile.CreateFromDirectory(fileAggregator.TempDir, Path.Combine(config.ZipFileLocation, config.ZipFileName));
 
             logger.Log("Done! On your desktop you will have a file called 'DN_Support.zip' which you can attach to your support ticket or reply.");

--- a/Command/Connection.cs
+++ b/Command/Connection.cs
@@ -64,8 +64,8 @@ namespace SupportTool.Command
             }
             catch (Exception)
             {
-                propagation.ShouldStop = true;
                 logger.Log("Pinging the servers failed, please check your connection.");
+                propagation.ShouldStop = true;
             }
         }
 

--- a/Command/TempDirectoryPreparation.cs
+++ b/Command/TempDirectoryPreparation.cs
@@ -11,12 +11,12 @@ namespace SupportTool.Command
 
             if (!tempDir.Exists)
             {
-                logger.Log(string.Format("Created {0}", fileAggregator.TempDir));
+                logger.Debug(string.Format("Created {0}", fileAggregator.TempDir));
                 Directory.CreateDirectory(fileAggregator.TempDir);
                 return;
             }
 
-            logger.Log(string.Format("Cleaning up old files in {0}", fileAggregator.TempDir));
+            logger.Debug(string.Format("Cleaning up old files in {0}", fileAggregator.TempDir));
 
             foreach (FileInfo file in tempDir.GetFiles())
             {

--- a/Logger/BackgroundReportLogger.cs
+++ b/Logger/BackgroundReportLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace SupportTool.Logger
 {
@@ -39,6 +40,13 @@ namespace SupportTool.Logger
         {
             // cannot clear anything in here, can only propagate the clear
             Inner.Clear(); 
+        }
+        
+        public void Debug(string message)
+        {
+#if DEBUG
+            Log(LoggingFormatter.FormatDebug(message));
+#endif
         }
     }
 }

--- a/Logger/InMemoryLogger.cs
+++ b/Logger/InMemoryLogger.cs
@@ -15,5 +15,12 @@ namespace SupportTool.Logger
         {
             Queue.Clear();
         }
+        
+        public void Debug(string message)
+        {
+#if DEBUG
+            Log(LoggingFormatter.FormatDebug(message));
+#endif
+        }
     }
 }

--- a/Logger/LoggingFormatter.cs
+++ b/Logger/LoggingFormatter.cs
@@ -8,5 +8,10 @@ namespace SupportTool.Logger
         {
             return String.Format("[{0:HH:mm:ss}] {1}", DateTime.Now, message);
         }
+
+        internal static string FormatDebug(string message)
+        {
+            return "[DEBUG] " + message;
+        }
     }
 }

--- a/Logger/TextBoxLogger.cs
+++ b/Logger/TextBoxLogger.cs
@@ -33,5 +33,12 @@ namespace SupportTool.Logger
             TextBox.AppendText(message + Environment.NewLine);
             TextBox.ScrollToEnd();
         }
+
+        public void Debug(string message)
+        {
+#if DEBUG
+            Log(LoggingFormatter.FormatDebug(message));
+#endif
+        }
     }
 }

--- a/LoggerInterface.cs
+++ b/LoggerInterface.cs
@@ -3,6 +3,8 @@
     public interface LoggerInterface
     {
         void Log(string message);
+        
+        void Debug(string message);
 
         void Clear();
     }


### PR DESCRIPTION
Closes #26.

This PR reduces the amount "clutter" the end-user gets in the output. This is a step towards possibly hiding the log by default and simply showing a progress bar. 

Excutable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1290058/support-tool.zip)

##### RELEASE
![image](https://user-images.githubusercontent.com/1754678/30243092-e1176328-95a2-11e7-909a-a71ac7686168.png)

##### DEBUG
![image](https://user-images.githubusercontent.com/1754678/30243078-b40ade50-95a2-11e7-9ec8-b8788a5ef990.png)
