### PR TITLE
Abstracted tool registration

### DIFF
--- a/SupportToolWindow.xaml
+++ b/SupportToolWindow.xaml
@@ -35,13 +35,7 @@
                     </MenuItem.Icon>
                 </MenuItem>
             </MenuItem>
-            <MenuItem Header="Tools" Padding="5" BorderThickness="0">
-                <MenuItem x:Name="ChangeInstallationDirectory" Header="Change Installation Directory" Click="ChangeChangeInstallationDirectory_Click">
-                    <MenuItem.Icon>
-                        <Image Source="Assets/DreadGame.ico"></Image>
-                    </MenuItem.Icon>
-                </MenuItem>
-            </MenuItem>
+            <MenuItem Header="Tools" Name="ToolsMenuItem" Padding="5" BorderThickness="0" />
             <MenuItem Header="Help" Padding="5" BorderThickness="0">
                 <MenuItem x:Name="OpenDocumentation" Header="Open Documentation" Click="OpenDocumentation_Click">
                     <MenuItem.Icon>

--- a/Tool/ChangeInstallationDirectory/InstallationFixer.cs
+++ b/Tool/ChangeInstallationDirectory/InstallationFixer.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Win32;
+using SupportTool.Dreadnought;
 using System.IO;
 
-namespace SupportTool.Dreadnought
+namespace SupportTool.Tool.ChangeInstallationDirectory
 {
     class InstallationFixer
     {

--- a/Tool/ChangeInstallationDirectory/ToolData.cs
+++ b/Tool/ChangeInstallationDirectory/ToolData.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace SupportTool.Tool.ChangeInstallationDirectory
+{
+    class ToolData : ToolInterface
+    {
+        private ToolWindow Window;
+
+        public ToolData(LoggerInterface logger)
+        {
+            Window = new ToolWindow(logger);
+        }
+
+        public string MenuHeader
+        {
+            get
+            {
+                return "Change Installation Directory";
+            }
+        }
+
+        public ImageSource MenuIcon
+        {
+            get
+            {
+                return new BitmapImage(new Uri("/Assets/DreadGame.ico", UriKind.Relative));
+            }
+        }
+
+        public Action OnShow
+        {
+            get
+            {
+                return delegate {
+                    Window.GuessInputValue();
+                };
+            }
+        }
+
+        public bool RequiresElevatedPermissions
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public Window ToolWindow
+        {
+            get
+            {
+                return Window;
+            }
+        }
+    }
+}

--- a/Tool/ChangeInstallationDirectory/ToolWindow.xaml
+++ b/Tool/ChangeInstallationDirectory/ToolWindow.xaml
@@ -1,9 +1,9 @@
-﻿<Window x:Class="SupportTool.Dreadnought.ChangeInstallationDirectory"
+﻿<Window x:Class="SupportTool.Tool.ChangeInstallationDirectory.ToolWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:SupportTool.Dreadnought"
+        xmlns:local="clr-namespace:SupportTool.Tool.ChangeInstallationDirectory"
         mc:Ignorable="d"
         Title="Change Installation Directory" Height="211" Width="403" WindowStyle="ToolWindow" ResizeMode="CanMinimize" ShowInTaskbar="True" WindowStartupLocation="CenterScreen">
     <Grid>

--- a/Tool/ChangeInstallationDirectory/ToolWindow.xaml.cs
+++ b/Tool/ChangeInstallationDirectory/ToolWindow.xaml.cs
@@ -1,20 +1,20 @@
 ﻿using Microsoft.Win32;
-using SupportTool.Dreadnought.Exception;
+using SupportTool.Dreadnought;
 using System;
 using System.ComponentModel;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 
-namespace SupportTool.Dreadnought
+namespace SupportTool.Tool.ChangeInstallationDirectory
 {
-    partial class ChangeInstallationDirectory : Window
+    partial class ToolWindow : Window
     {
-        private LoggerInterface logger;
+        private LoggerInterface Logger;
 
-        public ChangeInstallationDirectory(LoggerInterface logger)
+        public ToolWindow(LoggerInterface logger)
         {
-            this.logger = logger;
+            Logger = logger;
 
             InitializeComponent();
         }
@@ -52,12 +52,12 @@ namespace SupportTool.Dreadnought
             InstallationFixer.fixInstallationkey(InstallationInput.Text);
             InstallationFixer.fixUninstallLink(InstallationInput.Text);
 
-            this.logger.Log(String.Format("Installation directory set to {0}", InstallationFinder.findInRegistry()));
+            Logger.Log(String.Format("Installation directory set to {0}", InstallationFinder.findInRegistry()));
 
             Hide();
         }
 
-        public void guessInputValue()
+        public void GuessInputValue()
         {
             InstallationInput.TextChanged += InstallationInput_TextChanged;
 

--- a/Tool/ToolContainer.cs
+++ b/Tool/ToolContainer.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Windows.Controls;
+
+namespace SupportTool.Tool
+{
+    class ToolContainer
+    {
+        private Config Config;
+        private MenuItem ToolsMenuItem;
+        private List<ToolInterface> Tools = new List<ToolInterface>();
+
+        public ToolContainer(Config config, MenuItem toolsMenuItem)
+        {
+            Config = config;
+            ToolsMenuItem = toolsMenuItem;
+        }
+
+        public void RegisterTool(ToolInterface tool)
+        {
+            Tools.Add(tool);
+
+            MenuItem menuItem = new MenuItem()
+            {
+                Header = tool.MenuHeader
+            };
+
+            if (null != tool.MenuIcon)
+            {
+                menuItem.Icon = new Image()
+                {
+                    Source = tool.MenuIcon,
+                };
+            }
+
+            ToolsMenuItem.Items.Add(menuItem);
+
+            if (tool.RequiresElevatedPermissions && !Config.IsElevated)
+            {
+                // explicitly not returning, allows enable overrides
+                menuItem.IsEnabled = false;
+                menuItem.Header += " (Requires Admin Permissions)";
+            }
+
+            menuItem.Click += delegate
+            {
+                // in case the window is already visible, simply bring it to the foreground
+                if (tool.ToolWindow.IsVisible)
+                {
+                    tool.ToolWindow.Activate();
+                    return;
+                }
+
+                tool.ToolWindow.Show();
+                tool.ToolWindow.Activate();
+
+                // Anything the tool wants to do when the window becomes visible
+                tool.OnShow.Invoke();
+            };
+        }
+    }
+}

--- a/Tool/ToolInterface.cs
+++ b/Tool/ToolInterface.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace SupportTool.Tool
+{
+    interface ToolInterface
+    {
+        Window ToolWindow { get; }
+        string MenuHeader { get; }
+        ImageSource MenuIcon { get; }
+        Action OnShow { get; }
+        bool RequiresElevatedPermissions { get; }
+    }
+}

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -78,7 +78,10 @@
     </ApplicationDefinition>
     <Compile Include="AppVersion\XmlEntities.cs" />
     <Compile Include="AppVersion\VersionChecker.cs" />
-    <Page Include="Dreadnought\ChangeInstallationDirectory.xaml">
+    <Compile Include="Tool\ChangeInstallationDirectory\ToolData.cs" />
+    <Compile Include="Tool\ToolContainer.cs" />
+    <Compile Include="Tool\ToolInterface.cs" />
+    <Page Include="Tool\ChangeInstallationDirectory\ToolWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -104,12 +107,12 @@
     <Compile Include="Dreadnought\Exception\DreadnoughtShortcutNotFoundException.cs" />
     <Compile Include="Dreadnought\Exception\KeyNotFoundException.cs" />
     <Compile Include="Dreadnought\Exception\InvalidLocationException.cs" />
-    <Compile Include="Dreadnought\ChangeInstallationDirectory.xaml.cs">
-      <DependentUpon>ChangeInstallationDirectory.xaml</DependentUpon>
+    <Compile Include="Tool\ChangeInstallationDirectory\ToolWindow.xaml.cs">
+      <DependentUpon>ToolWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Dreadnought\Installation.cs" />
     <Compile Include="Dreadnought\InstallationFinder.cs" />
-    <Compile Include="Dreadnought\InstallationFixer.cs" />
+    <Compile Include="Tool\ChangeInstallationDirectory\InstallationFixer.cs" />
     <Compile Include="CommandCheckBoxInterface.cs" />
     <Compile Include="Logger\BackgroundReportLogger.cs" />
     <Compile Include="Logger\InMemoryLogger.cs" />
@@ -203,6 +206,7 @@
   <ItemGroup>
     <Resource Include="Assets\external.ico" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Tools will now have to be registered via the `ToolContainer`. This ensures that tools are all registered in the same way and can have a similar structure to avoid inconsistencies. 

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1308458/support-tool.zip)
