### PR TITLE
Added a tool to change module keybinds to azerty

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -2,7 +2,7 @@
 
 namespace SupportTool
 {
-    class Config
+    public class Config
     {
         public string Version { get; private set; }
         public string DnInstallationDirectory

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -1,10 +1,8 @@
 ﻿using SupportTool.AppVersion;
 using SupportTool.Command;
-using SupportTool.Dreadnought;
 using SupportTool.Logger;
 using SupportTool.Ping;
 using SupportTool.Tool;
-using SupportTool.Tool.ChangeInstallationDirectory;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -98,8 +96,9 @@ namespace SupportTool
             commandContainer.Add(new Archiver());
 
             toolContainer = new ToolContainer(config, ToolsMenuItem);
+            toolContainer.RegisterTool(new Tool.KeyboardSettings.ToolData(config, textBoxLogger));
             toolContainer.RegisterTool(new Tool.ChangeInstallationDirectory.ToolData(textBoxLogger));
-            
+
             updateLatestInfo();
             RunPings();
         }

--- a/Tool/ChangeInstallationDirectory/ToolWindow.xaml
+++ b/Tool/ChangeInstallationDirectory/ToolWindow.xaml
@@ -22,10 +22,10 @@
         <Button x:Name="FindInstallationButton" Content="Select Installation" Grid.Column="2" HorizontalAlignment="Left" Margin="0,0,0,0" Grid.Row="2" VerticalAlignment="Top" Width="110" Height="20" Click="FindInstallationButton_Click" RenderTransformOrigin="0.464,-0.95"/>
         <StatusBar x:Name="statusBar" HorizontalAlignment="Left" Margin="0,0,0,0" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Top" Width="387" Height="40" BorderThickness="0,1,0,0" Padding="10,5,10,5"  BorderBrush="LightGray">
             <StatusBarItem HorizontalAlignment="Center">
-                <Button x:Name="ApplyInstallationDirectory" Content="Save Changes" Width="100" Height="20" Click="ApplyInstallationDirectory_Click"/>
+                <Button x:Name="SaveChanges" Content="Save Changes" Width="100" Height="20" Click="SaveChanges_Click"/>
             </StatusBarItem>
         </StatusBar>
         <TextBlock x:Name="Instructions" Margin="10,10,0,0" HorizontalAlignment="Left" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" TextWrapping="Wrap" Text="Navigate to your Dreadnought installation directory and select &quot;DreadnoughtLauncher.exe&quot;." VerticalAlignment="Top" Width="365" Height="37"/>
-        <TextBlock x:Name="Tip" Margin="10" HorizontalAlignment="Left" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" TextWrapping="Wrap" Text="Saving changes will update the registry keys telling windows where Dreadnought is installed." VerticalAlignment="Top" Width="365" Height="37" FontStyle="Italic" TextDecorations="{x:Null}"/>
+        <TextBlock x:Name="Tip" Margin="10" HorizontalAlignment="Left" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" TextWrapping="Wrap" Text="Saving changes will update the registry keys telling windows where Dreadnought is installed." VerticalAlignment="Top" Width="365" Height="37" FontStyle="Italic"/>
     </Grid>
 </Window>

--- a/Tool/ChangeInstallationDirectory/ToolWindow.xaml.cs
+++ b/Tool/ChangeInstallationDirectory/ToolWindow.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Win32;
 using SupportTool.Dreadnought;
 using System;
-using System.ComponentModel;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -21,7 +20,7 @@ namespace SupportTool.Tool.ChangeInstallationDirectory
 
         private void InstallationInput_TextChanged(object sender, TextChangedEventArgs e)
         {
-            ApplyInstallationDirectory.IsEnabled = !InstallationInput.Text.Equals("");
+            SaveChanges.IsEnabled = !InstallationInput.Text.Equals("");
         }
 
         private void FindInstallationButton_Click(object sender, RoutedEventArgs e)
@@ -47,7 +46,7 @@ namespace SupportTool.Tool.ChangeInstallationDirectory
             }
         }
 
-        private void ApplyInstallationDirectory_Click(object sender, RoutedEventArgs e)
+        private void SaveChanges_Click(object sender, RoutedEventArgs e)
         {
             InstallationFixer.fixInstallationkey(InstallationInput.Text);
             InstallationFixer.fixUninstallLink(InstallationInput.Text);
@@ -80,12 +79,6 @@ namespace SupportTool.Tool.ChangeInstallationDirectory
             }
 
             InstallationInput.Text = installationDirectory;
-        }
-
-        protected override void OnClosing(CancelEventArgs e)
-        {
-            e.Cancel = true;
-            Hide();
         }
     }
 }

--- a/Tool/KeyboardSettings/ModulePreset.cs
+++ b/Tool/KeyboardSettings/ModulePreset.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SupportTool.Tool.KeyboardSettings
+{
+    public class ModulePreset
+    {
+        /// <summary>
+        /// Default available presets.
+        /// </summary>
+        public List<ModulePresetConfiguration> Presets = new List<ModulePresetConfiguration>()
+        {
+            new ModulePresetConfiguration("Qwerty", "One", "Two", "Three", "Four"),
+            new ModulePresetConfiguration("Azerty", "Ampersand", "E_AccentAigu", "Quote", "Apostrophe"),
+        };
+
+        /// <summary>
+        /// Returns the active configuration.
+        /// 
+        /// Will be null in the following cases:
+        ///  - input.ini does not exist
+        ///  - input.ini does not contain the 4 settings
+        ///  - found more than 4 things to add
+        /// </summary>
+        public ModulePresetConfiguration ActiveConfiguration
+        {
+            get
+            {
+                if (!InputFile.Exists)
+                {
+                    return null;
+                }
+
+                Dictionary<string, string> settings;
+
+                try
+                {
+                    settings = SettingFinder.findSettings(InputFile);
+                }
+                catch (IndexOutOfRangeException)
+                {
+                    return null;
+                }
+
+                if (0 == settings.Count)
+                {
+                    return null;
+                }
+
+                return new ModulePresetConfiguration("Current", settings);
+            }
+        }
+        
+        private FileInfo InputFile;
+
+        public ModulePreset(Config config)
+        {
+            InputFile = new FileInfo(Path.Combine(config.DreadnoughtSettingsLocation, "input.ini"));
+        }
+
+        public void savePreset(ModulePresetConfiguration preset)
+        {
+            Dictionary<string, string> presetDictionary = preset.ToDictionary();
+            List<string> replaced = new List<string>(4);
+
+            string[] lines = File.ReadAllLines(InputFile.FullName);
+
+            for(int i = 0; i < lines.Length; i++)
+            {
+                Tuple<string, string> result = SettingFinder.findMatchingSetting(lines[i]);
+
+                if (null != result && !replaced.Contains(result.Item1))
+                {
+                    // ensures the setting is replaced only once, not touching the secondary option
+                    lines[i] = lines[i].Replace("Key="+result.Item2, "Key="+presetDictionary[result.Item1]);
+                    replaced.Add(result.Item1);
+                }
+            }
+            
+            using (FileStream stream = InputFile.Open(FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                // write back the new configuration
+                using (StreamWriter writer = new StreamWriter(stream))
+                {
+                    foreach (string line in lines)
+                    {
+                        writer.WriteLine(line);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tool/KeyboardSettings/ModulePresetConfiguration.cs
+++ b/Tool/KeyboardSettings/ModulePresetConfiguration.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+
+namespace SupportTool.Tool.KeyboardSettings
+{
+    public class ModulePresetConfiguration
+    {
+        public string Name;
+        public string Primary;
+        public string Secondary;
+        public string Perimeter;
+        public string Internal;
+
+        public ModulePresetConfiguration(string name, string primary, string secondary, string perimeter, string internalModule)
+        {
+            Name = name;
+            Primary = primary;
+            Secondary = secondary;
+            Perimeter = perimeter;
+            Internal = internalModule;
+        }
+
+        public ModulePresetConfiguration(string name, Dictionary<string, string> settings)
+        {
+            Name = name;
+            Primary = settings["TriggerAbilityOne"];
+            Secondary = settings["TriggerAbilityTwo"];
+            Perimeter = settings["TriggerAbilityThree"];
+            Internal = settings["TriggerAbilityFour"];
+        }
+
+        public Dictionary<string, string> ToDictionary()
+        {
+            return new Dictionary<string, string>(4)
+            {
+                { "TriggerAbilityOne", Primary },
+                { "TriggerAbilityTwo", Secondary },
+                { "TriggerAbilityThree", Perimeter },
+                { "TriggerAbilityFour", Internal },
+            };
+        }
+
+        public static bool operator ==(ModulePresetConfiguration presetA, ModulePresetConfiguration presetB)
+        {
+            if (ReferenceEquals(presetA, null))
+            {
+                return ReferenceEquals(presetB, null);
+
+            }
+            return presetA.Primary == presetB.Primary
+                && presetA.Secondary == presetB.Secondary
+                && presetA.Perimeter == presetB.Perimeter
+                && presetA.Internal == presetB.Internal;
+        }
+
+        public static bool operator !=(ModulePresetConfiguration presetA, ModulePresetConfiguration presetB)
+        {
+            return !(presetA == presetB);
+        }
+    }
+}

--- a/Tool/KeyboardSettings/ModulePresetConfiguration.cs
+++ b/Tool/KeyboardSettings/ModulePresetConfiguration.cs
@@ -44,8 +44,8 @@ namespace SupportTool.Tool.KeyboardSettings
             if (ReferenceEquals(presetA, null))
             {
                 return ReferenceEquals(presetB, null);
-
             }
+
             return presetA.Primary == presetB.Primary
                 && presetA.Secondary == presetB.Secondary
                 && presetA.Perimeter == presetB.Perimeter

--- a/Tool/KeyboardSettings/SettingFinder.cs
+++ b/Tool/KeyboardSettings/SettingFinder.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace SupportTool.Tool.KeyboardSettings
+{
+    class SettingFinder
+    {
+        static Regex regex = new Regex("^([a-zA-Z_0-9])+=\\(ActionName=\"(TriggerAbility(One|Two|Three|Four))\",Key=([a-zA-Z_]+),.*\\)$");
+
+        public static Dictionary<string, string> findSettings(FileInfo logFile)
+        {
+            StreamReader file = new StreamReader(logFile.FullName);
+            Dictionary<string, string> settings = new Dictionary<string, string>(4);
+
+            using (FileStream stream = logFile.OpenRead())
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                string line;
+                while ((line = file.ReadLine()) != null)
+                {
+                    Tuple<string, string> result = findMatchingSetting(line);
+
+                    if (null != result && !settings.ContainsKey(result.Item1))
+                    {
+                        settings.Add(result.Item1, result.Item2);
+                    }
+                }
+            }
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Returns a tuple where the first value is the ActionName and the
+        /// second is the selected Key.
+        /// 
+        /// Returns null if it didn't match
+        /// </summary>
+        /// <returns></returns>
+        public static Tuple<string, string> findMatchingSetting(string line)
+        {
+            MatchCollection matches = regex.Matches(line);
+            if (0 == matches.Count)
+            {
+                return null;
+            }
+
+            string moduleSlot = matches[0].Groups[2].ToString();
+            string shortcut = matches[0].Groups[4].ToString();
+
+            return Tuple.Create<string, string>(moduleSlot, shortcut);
+        }
+    }
+}

--- a/Tool/KeyboardSettings/ToolData.cs
+++ b/Tool/KeyboardSettings/ToolData.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace SupportTool.Tool.KeyboardSettings
+{
+    class ToolData : ToolInterface
+    {
+        private ToolWindow Window;
+
+        public ToolData(Config config, LoggerInterface logger)
+        {
+            Window = new ToolWindow(new ModulePreset(config), logger);
+        }
+
+        public string MenuHeader
+        {
+            get
+            {
+                return "Keyboard Settings";
+            }
+        }
+
+        public ImageSource MenuIcon
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public Action OnShow
+        {
+            get
+            {
+                return delegate {
+                    Window.InitializeKeybindings();
+                };
+            }
+        }
+
+        public bool RequiresElevatedPermissions
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public Window ToolWindow
+        {
+            get
+            {
+                return Window;
+            }
+        }
+    }
+}

--- a/Tool/KeyboardSettings/ToolWindow.xaml
+++ b/Tool/KeyboardSettings/ToolWindow.xaml
@@ -1,0 +1,64 @@
+﻿<Window x:Class="SupportTool.Tool.KeyboardSettings.ToolWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SupportTool.Tool.KeyboardSettings"
+        mc:Ignorable="d"
+        Title="Keyboard Settings" Height="217" Width="404" WindowStyle="ToolWindow" ResizeMode="CanMinimize" ShowInTaskbar="True" WindowStartupLocation="CenterScreen">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Row="1" Orientation="Vertical" HorizontalAlignment="Left" Width="190">
+            <GroupBox Header="Module Preset" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10">
+                <ComboBox x:Name="ModulePresetOptions" HorizontalAlignment="Left" Margin="5" VerticalAlignment="Top" Width="95" />
+            </GroupBox>
+            <TextBlock x:Name="Tip" FontStyle="Italic" Text="Make sure to close the game before making any changes." TextWrapping="Wrap" Margin="10" />
+            <TextBlock x:Name="Error" Foreground="Red" Text="No keybinds found. Save the keybinds in the Dreadnought client and try again." TextWrapping="Wrap" Margin="10" />
+        </StackPanel>
+
+        <StatusBar HorizontalAlignment="Left" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Top" Width="388" Height="40" BorderThickness="0,1,0,0" Padding="10,5,10,5"  BorderBrush="LightGray">
+            <StatusBarItem HorizontalAlignment="Center">
+                <Button x:Name="SaveChanges" Content="Save Changes" Width="100" Height="20" Click="SaveChanges_Click"/>
+            </StatusBarItem>
+        </StatusBar>
+
+        <Grid Grid.Row="1" Grid.Column="1" Margin="0,10,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" MinHeight="20"/>
+                <RowDefinition Height="Auto" MinHeight="20"/>
+                <RowDefinition Height="Auto" MinHeight="20"/>
+                <RowDefinition Height="Auto" MinHeight="20"/>
+                <RowDefinition Height="Auto" MinHeight="20"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" MinWidth="85"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Row="0">
+                <Run FontWeight="Bold">Module Slot</Run>
+            </TextBlock>
+            <TextBlock Grid.Row="0" Grid.Column="1">
+                <Run FontWeight="Bold">Shortcut</Run>
+            </TextBlock>
+            <TextBlock Grid.Row="1">Primary</TextBlock>
+            <TextBlock Grid.Row="1" Grid.Column="1" x:Name="PrimaryModule"/>
+            <TextBlock Grid.Row="2">Secondary</TextBlock>
+            <TextBlock Grid.Row="2" Grid.Column="1" x:Name="SecondaryModule"/>
+            <TextBlock Grid.Row="3">Perimeter</TextBlock>
+            <TextBlock Grid.Row="3" Grid.Column="1" x:Name="PerimeterModule"/>
+            <TextBlock Grid.Row="4">Internal</TextBlock>
+            <TextBlock Grid.Row="4" Grid.Column="1" x:Name="InternalModule"/>
+        </Grid>
+    </Grid>
+</Window>

--- a/Tool/KeyboardSettings/ToolWindow.xaml.cs
+++ b/Tool/KeyboardSettings/ToolWindow.xaml.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SupportTool.Tool.KeyboardSettings
+{
+    public partial class ToolWindow : Window
+    {
+        private LoggerInterface Logger;
+        private ModulePreset Preset;
+
+        public ToolWindow(ModulePreset modulePreset, LoggerInterface logger)
+        {
+            Preset = modulePreset;
+            Logger = logger;
+
+            InitializeComponent();
+
+            ModulePresetOptions.SelectionChanged += new SelectionChangedEventHandler(delegate (object sender, SelectionChangedEventArgs e)
+            {
+                ComboBox comboBox = (ComboBox)sender;
+                
+                if (-1 == comboBox.SelectedIndex || comboBox.SelectedIndex > (Preset.Presets.Count - 1))
+                {
+                    return;
+                }
+
+                ShowShortcutPreview(Preset.Presets[comboBox.SelectedIndex]);
+            });
+        }
+
+        public void InitializeKeybindings()
+        {
+            bool selected = false;
+            SaveChanges.IsEnabled = false;
+            ModulePresetOptions.IsEnabled = false;
+            Tip.Visibility = Visibility.Collapsed;
+            Error.Visibility = Visibility.Collapsed;
+
+            ModulePresetConfiguration current = Preset.ActiveConfiguration;
+
+            if (null == current)
+            {
+                Error.Visibility = Visibility.Visible;
+                return;
+            }
+
+            Tip.Visibility = Visibility.Visible;
+
+            ModulePresetOptions.Items.Clear();
+
+            foreach (ModulePresetConfiguration preset in Preset.Presets)
+            {
+                if (preset == current)
+                {
+                    selected = true;
+                }
+
+                ModulePresetOptions.Items.Add(new ComboBoxItem()
+                {
+                    Content = preset.Name,
+                    IsSelected = preset == current,
+                });
+            }
+
+            ModulePresetOptions.Items.Add(new ComboBoxItem()
+            {
+                Content = current.Name,
+                IsSelected = !selected,
+                IsEnabled = false,
+            });
+
+            List<ModulePresetConfiguration> presets = new List<ModulePresetConfiguration>() { current };
+            presets.AddRange(Preset.Presets);
+
+            ShowShortcutPreview(presets[ModulePresetOptions.SelectedIndex]);
+
+            SaveChanges.IsEnabled = true;
+            ModulePresetOptions.IsEnabled = true;
+        }
+
+        private void ShowShortcutPreview(ModulePresetConfiguration preset)
+        {
+            PrimaryModule.Text = preset.Primary;
+            SecondaryModule.Text = preset.Secondary;
+            PerimeterModule.Text = preset.Perimeter;
+            InternalModule.Text = preset.Internal;
+        }
+
+        private void SaveChanges_Click(object sender, RoutedEventArgs e)
+        {
+            ModulePresetConfiguration preset = Preset.Presets[ModulePresetOptions.SelectedIndex];
+
+            Preset.savePreset(preset);
+
+            Logger.Log(String.Format("Module preset set to {0}", preset.Name));
+
+            Hide();
+        }
+    }
+}

--- a/Tool/KeyboardSettings/ToolWindow.xaml.cs
+++ b/Tool/KeyboardSettings/ToolWindow.xaml.cs
@@ -21,12 +21,20 @@ namespace SupportTool.Tool.KeyboardSettings
             {
                 ComboBox comboBox = (ComboBox)sender;
                 
-                if (-1 == comboBox.SelectedIndex || comboBox.SelectedIndex > (Preset.Presets.Count - 1))
+                if (-1 == comboBox.SelectedIndex || comboBox.SelectedIndex > Preset.Presets.Count)
                 {
                     return;
                 }
 
+                if (comboBox.SelectedIndex == Preset.Presets.Count)
+                {
+                    ShowShortcutPreview(Preset.ActiveConfiguration);
+                    SaveChanges.IsEnabled = false;
+                    return;
+                }
+
                 ShowShortcutPreview(Preset.Presets[comboBox.SelectedIndex]);
+                SaveChanges.IsEnabled = true;
             });
         }
 
@@ -71,12 +79,11 @@ namespace SupportTool.Tool.KeyboardSettings
                 IsEnabled = false,
             });
 
-            List<ModulePresetConfiguration> presets = new List<ModulePresetConfiguration>() { current };
-            presets.AddRange(Preset.Presets);
-
+            List<ModulePresetConfiguration> presets = new List<ModulePresetConfiguration>(Preset.Presets) { current };
+            
             ShowShortcutPreview(presets[ModulePresetOptions.SelectedIndex]);
 
-            SaveChanges.IsEnabled = true;
+            SaveChanges.IsEnabled = current != presets[ModulePresetOptions.SelectedIndex];
             ModulePresetOptions.IsEnabled = true;
         }
 

--- a/Tool/ToolContainer.cs
+++ b/Tool/ToolContainer.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace SupportTool.Tool
@@ -41,6 +43,13 @@ namespace SupportTool.Tool
                 menuItem.Header += " (Requires Admin Permissions)";
             }
 
+            // ensures that the tool window doesn't close itself but merely hides.
+            tool.ToolWindow.Closing += new CancelEventHandler(delegate (object sender, CancelEventArgs e)
+            {
+                e.Cancel = true;
+                (sender as Window).Hide();
+            });
+
             menuItem.Click += delegate
             {
                 // in case the window is already visible, simply bring it to the foreground
@@ -54,7 +63,10 @@ namespace SupportTool.Tool
                 tool.ToolWindow.Activate();
 
                 // Anything the tool wants to do when the window becomes visible
-                tool.OnShow.Invoke();
+                if (null != tool.OnShow)
+                {
+                    tool.OnShow.Invoke();
+                }
             };
         }
     }

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -78,9 +78,20 @@
     </ApplicationDefinition>
     <Compile Include="AppVersion\XmlEntities.cs" />
     <Compile Include="AppVersion\VersionChecker.cs" />
+    <Compile Include="Tool\KeyboardSettings\ModulePreset.cs" />
+    <Compile Include="Tool\KeyboardSettings\ModulePresetConfiguration.cs" />
+    <Compile Include="Tool\KeyboardSettings\SettingFinder.cs" />
+    <Compile Include="Tool\KeyboardSettings\ToolData.cs" />
+    <Compile Include="Tool\KeyboardSettings\ToolWindow.xaml.cs">
+      <DependentUpon>ToolWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Tool\ChangeInstallationDirectory\ToolData.cs" />
     <Compile Include="Tool\ToolContainer.cs" />
     <Compile Include="Tool\ToolInterface.cs" />
+    <Page Include="Tool\KeyboardSettings\ToolWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Tool\ChangeInstallationDirectory\ToolWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
Closes #39.

This new tool allows Azerty users to easily switch to a config where they can use the modules on the buttons that would be 1, 2, 3 and 4 for the Qwerty layout.

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1309074/support-tool.zip)

![image](https://user-images.githubusercontent.com/1754678/30520872-6455722a-9bb6-11e7-8517-cdecdfcbff5a.png)
![image](https://user-images.githubusercontent.com/1754678/30520876-6c1252da-9bb6-11e7-9dab-52c6ce78bfcf.png)
![image](https://user-images.githubusercontent.com/1754678/30520880-768afa50-9bb6-11e7-8399-ec6a32cc36b1.png)
![image](https://user-images.githubusercontent.com/1754678/30520884-7c8e8ca0-9bb6-11e7-9026-8aadf8d006b1.png)
![image](https://user-images.githubusercontent.com/1754678/30520907-cbdb46fe-9bb6-11e7-961c-9ad752b8d744.png)
