### PR TITLE
Ensure icons are rendered as 16x16

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -49,5 +49,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.0.0")]
+[assembly: AssemblyVersion("2.6.1.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SupportToolWindow.xaml
+++ b/SupportToolWindow.xaml
@@ -26,12 +26,12 @@
             <MenuItem Header="Open" Padding="5" BorderThickness="0">
                 <MenuItem x:Name="OpenDreadnoughtInstallationDirectory" Header="Dreadnought Folder" Click="OpenDreadnoughtInstallationDirectory_Click">
                     <MenuItem.Icon>
-                        <Image Source="Assets/Folder.png"></Image>
+                        <Image Source="Assets/Folder.png" Stretch="Fill" Width="16" Height="16"></Image>
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem x:Name="OpenAggregatedFiles" Header="Collected Files" Click="OpenAggregatedFiles_Click">
                     <MenuItem.Icon>
-                        <Image Source="Assets/Folder.png"></Image>
+                        <Image Source="Assets/Folder.png" Stretch="Fill" Width="16" Height="16"></Image>
                     </MenuItem.Icon>
                 </MenuItem>
             </MenuItem>
@@ -39,7 +39,7 @@
             <MenuItem Header="Help" Padding="5" BorderThickness="0">
                 <MenuItem x:Name="OpenDocumentation" Header="Open Documentation" Click="OpenDocumentation_Click">
                     <MenuItem.Icon>
-                        <Image Source="Assets/external.ico"></Image>
+                        <Image Source="Assets/external.ico" Stretch="Fill" Width="16" Height="16"></Image>
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem x:Name="ShowMessageOfTheDay" Header="Show Message of the Day" Click="ShowMessageOfTheDay_Click" />

--- a/Tool/ToolContainer.cs
+++ b/Tool/ToolContainer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace SupportTool.Tool
 {
@@ -31,6 +32,9 @@ namespace SupportTool.Tool
                 menuItem.Icon = new Image()
                 {
                     Source = tool.MenuIcon,
+                    Stretch = Stretch.Fill,
+                    Width = 16,
+                    Height = 16,
                 };
             }
 


### PR DESCRIPTION
In some scenarios, the icons are not rendered at the right size, this should enforce the icon size. 

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1311500/support-tool.zip)
