### PR TITLE
Fixed a crash when registry key did not exist

### DIFF
--- a/Tool/ChangeInstallationDirectory/InstallationFixer.cs
+++ b/Tool/ChangeInstallationDirectory/InstallationFixer.cs
@@ -12,7 +12,7 @@ namespace SupportTool.Tool.ChangeInstallationDirectory
 
             if (null == registryKey)
             {
-                Registry.LocalMachine.CreateSubKey(Installation.InstallationKey);
+                registryKey = Registry.LocalMachine.CreateSubKey(Installation.InstallationKey);
             }
 
             registryKey.SetValue(Installation.InstallationValueName, installDir.Replace(@"\DreadnoughtLauncher.exe", ""));
@@ -24,7 +24,7 @@ namespace SupportTool.Tool.ChangeInstallationDirectory
 
             if (null == registryKey)
             {
-                Registry.LocalMachine.CreateSubKey(Installation.UninstallKey);
+                registryKey = Registry.LocalMachine.CreateSubKey(Installation.UninstallKey);
             }
 
             string dir = installDir.Replace(@"\DreadnoughtLauncher.exe", "");


### PR DESCRIPTION
Fixes #47 

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1732610/support-tool.zip)
