### PR TITLE
Add the option to start under debug and prepare 2.7.0

### DIFF
--- a/Command/HostDeveloper.cs
+++ b/Command/HostDeveloper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SupportTool.Dreadnought;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -74,15 +75,7 @@ namespace SupportTool.Command
                 logger.Log("A windows user account control popup will appear to run the Dreadnought launcher as administrator");
             }
                         
-            FileInfo reportFile = fileAggregator.AddExistingFile(hostDeveloperFile.FullName, DeveloperFile);
-
-            Process process = new Process();
-            process.EnableRaisingEvents = true;
-            process.StartInfo.UseShellExecute = true;
-            process.StartInfo.FileName = launcherExecutable.FullName;
-            process.StartInfo.CreateNoWindow = true;
-            process.StartInfo.Arguments = "/debug";
-            process.StartInfo.Verb = "runas";
+            Process process = DebugLauncher.CreateProcess(launcherExecutable.FullName);
 
             try
             {
@@ -93,7 +86,6 @@ namespace SupportTool.Command
                 if (e.NativeErrorCode == 1223) // operation cancelled by user
                 {
                     logger.Log("Skipping host.developer dump, this option requires administrative permissions.");
-                    propagation.ShouldStop = true;
                     return;
                 }
                 else
@@ -101,6 +93,8 @@ namespace SupportTool.Command
                     throw e;
                 }
             }
+
+            fileAggregator.AddExistingFile(hostDeveloperFile.FullName, DeveloperFile);
 
             DateTime firstWrite = hostDeveloperFile.Exists ? hostDeveloperFile.LastWriteTime : new DateTime();
 

--- a/Dreadnought/DebugLauncher.cs
+++ b/Dreadnought/DebugLauncher.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics;
+
+namespace SupportTool.Dreadnought
+{
+    class DebugLauncher
+    {
+        public static Process CreateProcess(string executable)
+        {
+            return new Process
+            {
+                EnableRaisingEvents = true,
+                StartInfo =
+                {
+                    UseShellExecute = true,
+                    FileName = executable,
+                    CreateNoWindow = true,
+                    Arguments = "/debug",
+                    Verb = "runas"
+                }
+            };
+        }
+    }
+}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -49,5 +49,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.1.0")]
+[assembly: AssemblyVersion("2.7.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SupportToolWindow.xaml
+++ b/SupportToolWindow.xaml
@@ -24,6 +24,11 @@
                 </ItemsPanelTemplate>
             </Menu.ItemsPanel>
             <MenuItem Header="Open" Padding="5" BorderThickness="0">
+                <MenuItem x:Name="RunDreadnoughtDebugLauncher" Header="Run Launcher in debug mode" Click="RunDreadnoughtDebugLauncher_Click">
+                    <MenuItem.Icon>
+                        <Image Source="Assets/dreadgame.ico" Stretch="Fill" Width="16" Height="16"></Image>
+                    </MenuItem.Icon>
+                </MenuItem>
                 <MenuItem x:Name="OpenDreadnoughtInstallationDirectory" Header="Dreadnought Folder" Click="OpenDreadnoughtInstallationDirectory_Click">
                     <MenuItem.Icon>
                         <Image Source="Assets/Folder.png" Stretch="Fill" Width="16" Height="16"></Image>

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using SupportTool.AppVersion;
 using SupportTool.Command;
+using SupportTool.Dreadnought;
 using SupportTool.Logger;
 using SupportTool.Ping;
 using SupportTool.Tool;
@@ -225,6 +226,32 @@ namespace SupportTool
         private void ShowMessageOfTheDay_Click(object sender, RoutedEventArgs e)
         {
             updateLatestInfo();
+        }
+
+        private void RunDreadnoughtDebugLauncher_Click(object sender, RoutedEventArgs e)
+        {
+            FileInfo launcherExecutable = new FileInfo(Path.Combine(config.DnInstallationDirectory, "DreadnoughtLauncher.exe"));
+
+            if (!launcherExecutable.Exists)
+            {
+                textBoxLogger.Log("Could not reliably find the Dreadnought installation directory (Hint: try Tools > Change Installation Directory)");
+                return;
+            }
+
+            Process process = DebugLauncher.CreateProcess(launcherExecutable.FullName);
+
+            try
+            {
+                process.Start();
+            }
+            catch (Win32Exception ex)
+            {
+                if (ex.NativeErrorCode == 1223) // operation cancelled by user
+                {
+                    textBoxLogger.Log("Starting the debug launcher requires administrative permissions.");
+                    return;
+                }
+            }
         }
     }
 }

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -78,6 +78,7 @@
     </ApplicationDefinition>
     <Compile Include="AppVersion\XmlEntities.cs" />
     <Compile Include="AppVersion\VersionChecker.cs" />
+    <Compile Include="Dreadnought\DebugLauncher.cs" />
     <Compile Include="Ping\PingStorage.cs" />
     <Compile Include="Tool\KeyboardSettings\ModulePreset.cs" />
     <Compile Include="Tool\KeyboardSettings\ModulePresetConfiguration.cs" />


### PR DESCRIPTION
Adds the option to start the launcher under debug mode.

![image](https://user-images.githubusercontent.com/1754678/36328799-d321f30c-1363-11e8-9457-d50bfa367252.png)

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1732784/support-tool.zip)
