### PR TITLE
Added a ping export tool

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
     </startup>
 </configuration>

--- a/Ping/PingResult.cs
+++ b/Ping/PingResult.cs
@@ -2,7 +2,7 @@
 
 namespace SupportTool.Ping
 {
-    class PingResult
+    public class PingResult
     {
         public string Host { get; private set; }
         public bool Successful { get; private set; }

--- a/Ping/Pinger.cs
+++ b/Ping/Pinger.cs
@@ -57,7 +57,7 @@ namespace SupportTool.Ping
                     }
 
                     string error = item.Key.Equals(reply.Address.ToString())
-                        ? String.Format("Connecting to {0} failed. Error: {2}.", item.Key, reply.Status.ToString())
+                        ? String.Format("Connecting to {0} failed. Error: {1}.", item.Key, reply.Status.ToString())
                         : String.Format("Connecting to {0} (resolved to {1}) failed. Error: {2}.", item.Key, reply.Address, reply.Status.ToString());
 
                     errors.Add(error);

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -49,5 +49,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.7.0.0")]
+[assembly: AssemblyVersion("2.8.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SupportTool.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SupportTool.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -101,6 +101,7 @@ namespace SupportTool
             toolContainer = new ToolContainer(config, ToolsMenuItem);
             toolContainer.RegisterTool(new Tool.KeyboardSettings.ToolData(config, textBoxLogger));
             toolContainer.RegisterTool(new Tool.ChangeInstallationDirectory.ToolData(textBoxLogger));
+            toolContainer.RegisterTool(new Tool.PingExport.ToolData(pingStorage, config, textBoxLogger));
 
             updateLatestInfo();
             RunPings();
@@ -145,7 +146,7 @@ namespace SupportTool
 
         private void StartPing(object sender, DoWorkEventArgs e)
         { 
-            PingWorker.ReportProgress(1, pingStorage.ping());
+            PingWorker.ReportProgress(1, pingStorage.Ping());
         }
 
         private void ReportPing(object sender, ProgressChangedEventArgs e)

--- a/Tool/ChangeInstallationDirectory/ToolData.cs
+++ b/Tool/ChangeInstallationDirectory/ToolData.cs
@@ -14,46 +14,14 @@ namespace SupportTool.Tool.ChangeInstallationDirectory
             Window = new ToolWindow(logger);
         }
 
-        public string MenuHeader
-        {
-            get
-            {
-                return "Change Installation Directory";
-            }
-        }
+        public string MenuHeader { get { return "Change Installation Directory"; }}
 
-        public ImageSource MenuIcon
-        {
-            get
-            {
-                return new BitmapImage(new Uri("/Assets/DreadGame.ico", UriKind.Relative));
-            }
-        }
+        public ImageSource MenuIcon { get { return new BitmapImage(new Uri("/Assets/DreadGame.ico", UriKind.Relative)); } }
 
-        public Action OnShow
-        {
-            get
-            {
-                return delegate {
-                    Window.GuessInputValue();
-                };
-            }
-        }
+        public Action OnShow { get { return delegate { Window.GuessInputValue(); }; } }
 
-        public bool RequiresElevatedPermissions
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool RequiresElevatedPermissions { get { return true; } }
 
-        public Window ToolWindow
-        {
-            get
-            {
-                return Window;
-            }
-        }
+        public Window ToolWindow { get { return Window; } }
     }
 }

--- a/Tool/ChangeInstallationDirectory/ToolWindow.xaml
+++ b/Tool/ChangeInstallationDirectory/ToolWindow.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:SupportTool.Tool.ChangeInstallationDirectory"
         mc:Ignorable="d"
         Title="Change Installation Directory" Height="211" Width="403" WindowStyle="ToolWindow" ResizeMode="CanMinimize" ShowInTaskbar="True" WindowStartupLocation="CenterScreen">
     <Grid>

--- a/Tool/KeyboardSettings/ToolData.cs
+++ b/Tool/KeyboardSettings/ToolData.cs
@@ -13,46 +13,14 @@ namespace SupportTool.Tool.KeyboardSettings
             Window = new ToolWindow(new ModulePreset(config), logger);
         }
 
-        public string MenuHeader
-        {
-            get
-            {
-                return "Keyboard Settings";
-            }
-        }
+        public string MenuHeader { get { return "Keyboard Settings"; } }
 
-        public ImageSource MenuIcon
-        {
-            get
-            {
-                return null;
-            }
-        }
+        public ImageSource MenuIcon { get { return null; } }
 
-        public Action OnShow
-        {
-            get
-            {
-                return delegate {
-                    Window.InitializeKeybindings();
-                };
-            }
-        }
+        public Action OnShow { get { return delegate { Window.InitializeKeybindings(); }; } }
 
-        public bool RequiresElevatedPermissions
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public bool RequiresElevatedPermissions { get { return false; } }
 
-        public Window ToolWindow
-        {
-            get
-            {
-                return Window;
-            }
-        }
+        public Window ToolWindow { get { return Window; } }
     }
 }

--- a/Tool/KeyboardSettings/ToolWindow.xaml
+++ b/Tool/KeyboardSettings/ToolWindow.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:SupportTool.Tool.KeyboardSettings"
         mc:Ignorable="d"
         Title="Keyboard Settings" Height="217" Width="404" WindowStyle="ToolWindow" ResizeMode="CanMinimize" ShowInTaskbar="True" WindowStartupLocation="CenterScreen">
     <Grid>

--- a/Tool/PingExport/ToolData.cs
+++ b/Tool/PingExport/ToolData.cs
@@ -1,0 +1,27 @@
+﻿using SupportTool.Ping;
+using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace SupportTool.Tool.PingExport
+{
+    class ToolData : ToolInterface
+    {
+        private ToolWindow Window;
+
+        public ToolData(PingStorage pingStorage, Config config, LoggerInterface logger)
+        {
+            Window = new ToolWindow(pingStorage, config, logger);
+        }
+
+        public string MenuHeader { get { return "Export Ping Data"; } }
+
+        public ImageSource MenuIcon { get { return null; } }
+
+        public Action OnShow { get { return null; } }
+
+        public bool RequiresElevatedPermissions { get { return false; } }
+
+        public Window ToolWindow { get { return Window; } }
+    }
+}

--- a/Tool/PingExport/ToolWindow.xaml
+++ b/Tool/PingExport/ToolWindow.xaml
@@ -1,0 +1,26 @@
+﻿<Window x:Class="SupportTool.Tool.PingExport.ToolWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Export Ping Data" Height="150" Width="350" WindowStyle="ToolWindow" ResizeMode="CanMinimize" ShowInTaskbar="True" WindowStartupLocation="CenterScreen">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Margin="10" Grid.RowSpan="2" TextWrapping="Wrap">Exporting the ping data will create a Comma Separated File (CSV) on your desktop. The server is pinged once every second.</TextBlock>
+
+        <StatusBar HorizontalAlignment="Left" Grid.Row="2" Grid.Column="0" VerticalAlignment="Top" Width="344" Height="40" BorderThickness="0,1,0,0" Padding="10,5,10,5"  BorderBrush="LightGray">
+            <StatusBarItem HorizontalAlignment="Center">
+                <Button x:Name="ExportPing" Content="Export" Width="100" Height="20" Click="ExportPing_Click"/>
+            </StatusBarItem>
+        </StatusBar>
+    </Grid>
+</Window>

--- a/Tool/PingExport/ToolWindow.xaml.cs
+++ b/Tool/PingExport/ToolWindow.xaml.cs
@@ -1,0 +1,43 @@
+﻿using SupportTool.Ping;
+using System.IO;
+using System.Text;
+using System.Windows;
+
+namespace SupportTool.Tool.PingExport
+{
+    public partial class ToolWindow : Window
+    {
+        private LoggerInterface Logger;
+        private Config Config;
+        private PingStorage PingStorage;
+
+        public ToolWindow(PingStorage pingStorage, Config config, LoggerInterface logger)
+        {
+            PingStorage = pingStorage;
+            Config = config;
+            Logger = logger;
+
+            InitializeComponent();
+        }
+
+        private void ExportPing_Click(object sender, RoutedEventArgs e)
+        {
+            var pings = PingStorage.Pings;
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.AppendLine("Timestamp, AveragePing");
+
+            foreach (var result in pings)
+            {
+                stringBuilder.AppendLine(string.Format("{0}, {1}", result.Timestamp, result.AveragePing));
+            }
+
+            var exportFile = Path.Combine(Config.ZipFileLocation, "DN_Support_ping_export.csv");
+            File.WriteAllText(exportFile, stringBuilder.ToString());
+
+            Logger.Log(string.Format("Ping data exported to {0}", exportFile));
+
+            Hide();
+        }
+    }
+}

--- a/support-tool.csproj
+++ b/support-tool.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SupportTool</RootNamespace>
     <AssemblyName>support-tool</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -29,6 +29,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -88,6 +89,10 @@
       <DependentUpon>ToolWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Tool\ChangeInstallationDirectory\ToolData.cs" />
+    <Compile Include="Tool\PingExport\ToolData.cs" />
+    <Compile Include="Tool\PingExport\ToolWindow.xaml.cs">
+      <DependentUpon>ToolWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Tool\ToolContainer.cs" />
     <Compile Include="Tool\ToolInterface.cs" />
     <Page Include="Tool\KeyboardSettings\ToolWindow.xaml">
@@ -147,6 +152,10 @@
       <DependentUpon>SupportToolWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="Tool\PingExport\ToolWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs">


### PR DESCRIPTION
Raises the version of .NET to 4.6 instead of 4.5 and adds an export option for csv data of the collected pings while the tool was running.

![image](https://user-images.githubusercontent.com/1754678/36352088-eaf9a032-14b3-11e8-9f1e-92af217486fd.png)

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1734733/support-tool.zip)

Closes #38