### PR TITLE
Also include the ping log in the zip archive

### DIFF
--- a/Command/Connection.cs
+++ b/Command/Connection.cs
@@ -4,11 +4,19 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace SupportTool.Command
 {
     class Connection : CommandInterface, CommandCheckBoxInterface
     {
+        private PingStorage PingStorage;
+
+        public Connection(PingStorage pingStorage)
+        {
+            PingStorage = pingStorage;
+        }
+
         public string ConfigPropertyPath
         {
             get
@@ -67,6 +75,8 @@ namespace SupportTool.Command
                 logger.Log("Pinging the servers failed, please check your connection.");
                 propagation.ShouldStop = true;
             }
+
+            AddStoredPingsAsCsv(config, fileAggregator);
         }
 
         private void CheckConnnection(List<string> ipAddresses, FileAggregator fileAggregator, LoggerInterface logger)
@@ -133,6 +143,21 @@ namespace SupportTool.Command
             ));
             
             return result.Errors;
+        }
+
+        private void AddStoredPingsAsCsv(Config config, FileAggregator fileAggregator)
+        {
+            FileInfo reportFile = fileAggregator.AddVirtualFile("ping-log.csv");
+
+            using (StreamWriter writer = reportFile.CreateText())
+            {
+                writer.WriteLine("Timestamp, AveragePing");
+
+                foreach (var result in PingStorage.Pings)
+                {
+                    writer.WriteLine(string.Format("{0}, {1}", result.Timestamp, result.AveragePing));
+                }
+            }
         }
     }
 }

--- a/Command/TempDirectoryPreparation.cs
+++ b/Command/TempDirectoryPreparation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace SupportTool.Command
 {

--- a/SupportToolWindow.xaml.cs
+++ b/SupportToolWindow.xaml.cs
@@ -91,7 +91,7 @@ namespace SupportTool
             commandContainer.Add(new CustomerSupportReadme());
             commandContainer.Add(new DxDiag());
             commandContainer.Add(new MsInfo());
-            commandContainer.Add(new Connection());
+            commandContainer.Add(new Connection(pingStorage));
             commandContainer.Add(new DreadnoughtLogs());
             commandContainer.Add(new DreadnoughtSettings());
             commandContainer.Add(new DreadnoughtCrashDumps());

--- a/Tool/PingExport/ToolWindow.xaml.cs
+++ b/Tool/PingExport/ToolWindow.xaml.cs
@@ -22,12 +22,11 @@ namespace SupportTool.Tool.PingExport
 
         private void ExportPing_Click(object sender, RoutedEventArgs e)
         {
-            var pings = PingStorage.Pings;
             var stringBuilder = new StringBuilder();
 
             stringBuilder.AppendLine("Timestamp, AveragePing");
 
-            foreach (var result in pings)
+            foreach (var result in PingStorage.Pings)
             {
                 stringBuilder.AppendLine(string.Format("{0}, {1}", result.Timestamp, result.AveragePing));
             }


### PR DESCRIPTION
This change adds the previously added csv export to the zip archive. 

Executable: [support-tool.zip](https://github.com/dreadnought-friends/support-tool/files/1734872/support-tool.zip)
